### PR TITLE
DB-12042 JMS Input Source

### DIFF
--- a/spark3.0/build-assembly.sbt
+++ b/spark3.0/build-assembly.sbt
@@ -21,7 +21,13 @@ assemblyMergeStrategy in assembly := {
   case PathList("com", "splicemachine", "utils", _*)  => MergeStrategy.first
   case PathList("net", "jcip", "annotations", "GuardedBy.class") => MergeStrategy.last
   case PathList(ps @ _*) if ps.last endsWith ".css"  => MergeStrategy.first
+  case PathList("org", "slf4j", _*)  => MergeStrategy.first
+  case PathList("org", "apache", "commons", "logging", _*)  => MergeStrategy.first
+  case PathList("javax", "jms", _*)  => MergeStrategy.first
+  case PathList("javax", "annotation", _*)  => MergeStrategy.first
+  case PathList("google", "protobuf", _*)  => MergeStrategy.first
   case "module-info.class" => MergeStrategy.discard
+  case "log4j.properties" => MergeStrategy.discard
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)
@@ -30,6 +36,7 @@ assemblyMergeStrategy in assembly := {
 // FIXME There has to be a better way to exclude all the jars (!)
 assemblyExcludedJars in assembly := {
   val excludedDeps = Set(
+    "log4j.properties",
     // Conflicts with splice_aws-2.8.0.1926-shade.jar
     "aws-java-sdk-bundle-1.11.134.jar",
     "aws-java-sdk-kms-1.11.82.jar",

--- a/spark3.0/build.sbt
+++ b/spark3.0/build.sbt
@@ -48,10 +48,8 @@ val excludedDepsNonSpark = Seq(
   ExclusionRule(organization = "org.scala-lang.modules", name = "scala-parser-combinators_2.11")
 )
 
-val excludedDeps = excludedDepsNonSpark ++ Seq(
-  // FIXME Somehow 2.2.0 is pulled down
-  ExclusionRule(organization = "org.apache.spark"),
-)
+val excludedDeps =
+  ExclusionRule(organization = "org.apache.spark") +: excludedDepsNonSpark
 
 libraryDependencies ++= Seq(
   "splice_spark2",

--- a/spark3.0/build.sbt
+++ b/spark3.0/build.sbt
@@ -1,6 +1,6 @@
 name := "splice-machine-spark-connector"
 
-val spliceVersion = "3.2.0.2001-SNAPSHOT"
+val spliceVersion = "3.1.0.2016"
 
 version := spliceVersion
 
@@ -38,16 +38,19 @@ kafkaVersion := s"2.2.1-${distro.value}"
 // java.lang.NoClassDefFoundError: com/splicemachine/access/HConfiguration
 // https://stackoverflow.com/a/46763742/1305344
 
-val excludedDeps = Seq(
+val excludedDepsNonSpark = Seq(
   ExclusionRule(organization = "org.xerial.snappy", name = "snappy-java"),
   ExclusionRule(organization = "tomcat", name = "jasper-compiler"),
-  // FIXME Somehow 2.2.0 is pulled down
-  ExclusionRule(organization = "org.apache.spark"),
   // Added later separately
   ExclusionRule(organization = "com.splicemachine", name = "scala_util"),
   ExclusionRule(organization = "javax.ws.rs", name = "javax.ws.rs-api"),
   ExclusionRule(organization = "org.apache.kafka", name = "kafka_2.11"),
   ExclusionRule(organization = "org.scala-lang.modules", name = "scala-parser-combinators_2.11")
+)
+
+val excludedDeps = excludedDepsNonSpark ++ Seq(
+  // FIXME Somehow 2.2.0 is pulled down
+  ExclusionRule(organization = "org.apache.spark"),
 )
 
 libraryDependencies ++= Seq(
@@ -91,7 +94,13 @@ libraryDependencies += "org.apache.hbase" % "hbase-hadoop-compat" % hbaseVersion
 libraryDependencies += "org.apache.hbase" % "hbase-zookeeper" % hbaseVersion.value excludeAll (excludedDeps: _*)
 libraryDependencies += "org.apache.hbase" % "hbase-mapreduce" % hbaseVersion.value excludeAll (excludedDeps: _*)
 libraryDependencies += "org.apache.kafka" % "kafka_2.12" % kafkaVersion.value excludeAll (excludedDeps: _*)
+libraryDependencies += "org.apache.spark" % "spark-sql-kafka-0-10_2.12" % sparkVersion.value excludeAll (excludedDepsNonSpark: _*)
 libraryDependencies += "org.scala-lang.modules" % "scala-parser-combinators_2.12" % "1.1.2" excludeAll (excludedDeps: _*)
+libraryDependencies += "org.apache.activemq" % "activemq-all" % "5.12.0" excludeAll (excludedDeps: _*)
+libraryDependencies += "com.rabbitmq.jms" % "rabbitmq-jms" % "1.11.0" excludeAll (excludedDeps: _*)
+libraryDependencies += "io.confluent" % "kafka-jms-client" % "5.1.0" excludeAll (excludedDeps: _*)
+libraryDependencies += "org.apache.geronimo.specs" % "geronimo-jms_1.1_spec" % "1.1" excludeAll (excludedDeps: _*)
+libraryDependencies += "com.ibm.mq" % "com.ibm.mq.allclient" % "9.2.2.0" excludeAll (excludedDeps: _*)
 
 // For development only / local Splice SNAPSHOTs
 resolvers += Resolver.mavenLocal
@@ -100,6 +109,8 @@ resolvers +=
     .withAllowInsecureProtocol(true)
 resolvers +=
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
+resolvers +=
+  "Confluent Repository" at "https://packages.confluent.io/maven/"
 
 // com.fasterxml.jackson.databind.JsonMappingException: Incompatible Jackson version: 2.9.2
 libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.0" force() excludeAll (excludedDeps: _*)

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/ConnectionFactoryProvider.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/ConnectionFactoryProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ * Copyright 2021 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import java.util.Properties

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/ConnectionFactoryProvider.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/ConnectionFactoryProvider.scala
@@ -1,0 +1,76 @@
+package com.splicemachine.spark.jms
+
+import java.util.Properties
+import javax.jms.ConnectionFactory
+
+import com.rabbitmq.jms.admin.RMQConnectionFactory
+import io.confluent.kafka.jms.KafkaConnectionFactory
+import org.apache.activemq.ActiveMQConnectionFactory
+
+/**
+  * Created by exa00015 on 24/12/18.
+  */
+trait ConnectionFactoryProvider {
+
+  def createConnection(options:Map[String,String]):ConnectionFactory
+
+}
+
+class AMQConnectionFactoryProvider extends ConnectionFactoryProvider {
+
+  override def createConnection(options: Map[String, String]): ConnectionFactory = {
+    new ActiveMQConnectionFactory
+  }
+}
+
+class IBMMQConnectionFactoryProvider extends ConnectionFactoryProvider {
+
+  override def createConnection(options: Map[String, String]): ConnectionFactory = {
+    import com.ibm.msg.client.wmq.common.CommonConstants
+    import com.ibm.msg.client.jms.JmsConstants
+    val cf = com.ibm.msg.client.jms.JmsFactoryFactory.getInstance(JmsConstants.WMQ_PROVIDER).createConnectionFactory
+    cf.setStringProperty(CommonConstants.WMQ_HOST_NAME, options.getOrElse("host", throw new IllegalArgumentException("Option host is required")))
+    cf.setIntProperty(CommonConstants.WMQ_PORT, options.getOrElse("port", throw new IllegalArgumentException("Option port is required")).toInt)
+    cf.setStringProperty(CommonConstants.WMQ_CHANNEL, options.getOrElse("channel", throw new IllegalArgumentException("Option channel is required")))
+    cf.setIntProperty(CommonConstants.WMQ_CONNECTION_MODE, CommonConstants.WMQ_CM_CLIENT)
+    cf.setStringProperty(CommonConstants.WMQ_QUEUE_MANAGER, options.getOrElse("queue_manager", throw new IllegalArgumentException("Option queue_manager is required")))
+    options.get("application").foreach(
+      app => cf.setStringProperty(CommonConstants.WMQ_APPLICATIONNAME, app)
+    )
+    cf.setBooleanProperty(JmsConstants.USER_AUTHENTICATION_MQCSP, true)
+    options.get("userid").foreach(
+      userid => cf.setStringProperty(JmsConstants.USERID, userid)
+    )
+    options.get("password").foreach(
+      password => cf.setStringProperty(JmsConstants.PASSWORD, password)
+    )
+    cf
+  }
+}
+
+class RMQConnectionFactoryProvider extends ConnectionFactoryProvider {
+
+  override def createConnection(options: Map[String, String]): ConnectionFactory = {
+    val connectionFactory = new RMQConnectionFactory
+    connectionFactory.setUsername(options.getOrElse("username",throw new IllegalArgumentException("Option username is required")))
+    connectionFactory.setPassword(options.getOrElse("password",throw new IllegalArgumentException("Option password is required")))
+    connectionFactory.setVirtualHost(options.getOrElse("virtualhost",throw new IllegalArgumentException("Option virtualhost is required")))
+    connectionFactory.setHost(options.getOrElse("host",throw new IllegalArgumentException("Option host is required")))
+    connectionFactory.setPort(options.getOrElse("port",throw new IllegalArgumentException("Option port is required")).toInt)
+    connectionFactory
+  }
+}
+
+class KafkaConnectionFactoryProvider extends ConnectionFactoryProvider {
+
+  override def createConnection(options: Map[String, String]): ConnectionFactory = {
+    val props = new Properties
+    props.put("bootstrap.servers", options.getOrElse("bootstrap.servers",throw new IllegalArgumentException("Option bootstrap.servers is required")))
+    props.put("zookeeper.connect", options.getOrElse("zookeeper.connect",throw new IllegalArgumentException("Option zookeeper.connect is required")))
+    props.put("client.id", options.getOrElse("client.id",throw new IllegalArgumentException("Option client.id is required" )))
+    val connectionFactory = new KafkaConnectionFactory(props)
+    connectionFactory
+  }
+
+}
+

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/DataFrameRelation.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/DataFrameRelation.scala
@@ -1,0 +1,21 @@
+package com.splicemachine.spark.jms
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+/**
+  * Created by exa00015 on 24/12/18.
+  */
+class DataFrameRelation(override val sqlContext: SQLContext,data:DataFrame) extends BaseRelation with TableScan with Serializable {
+
+  override def schema: StructType = {
+    data.schema
+  }
+
+  override def buildScan(): RDD[Row] = {
+    data.rdd
+  }
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/DataFrameRelation.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/DataFrameRelation.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import org.apache.spark.rdd.RDD

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/DefaultSource.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/DefaultSource.scala
@@ -1,0 +1,80 @@
+package com.splicemachine.spark.jms
+
+
+import javax.jms.Session
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.execution.streaming.{Sink, Source}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.streaming.{DataStreamReader, OutputMode}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.jms.JmsStreamingSource
+
+/**
+  * Created by exa00015 on 17/12/18.
+  */
+private[jms] class DefaultSource extends RelationProvider with SchemaRelationProvider with CreatableRelationProvider with DataSourceRegister with StreamSourceProvider with StreamSinkProvider{
+
+  override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation = {
+    createRelation(sqlContext, parameters, null)
+  }
+
+  override def createRelation(sqlContext: SQLContext, parameters: Map[String, String], schema: StructType): BaseRelation = {
+    parameters.get("queue") match {
+      case Some(queue) => new JmsDatasourceRelation(sqlContext, parameters)
+      case None => throw new IllegalArgumentException("Option queue is needed")
+    }
+  }
+
+
+  override def shortName(): String = "jms"
+
+  override def createRelation(sqlContext: SQLContext, mode: SaveMode, parameters: Map[String, String], data: DataFrame): BaseRelation = {
+    if (mode == SaveMode.Overwrite) {
+      throw new UnsupportedOperationException("Data in a kafka topic cannot be overidden !"
+        + " Delete topic to implement this functionality")
+    }
+    data.foreachPartition((rowIter: Iterator[Row]) => {
+      val connection = DefaultSource.connectionFactory(parameters).createConnection
+      val session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+      val queue = session.createQueue(parameters.getOrElse("queue",throw new IllegalArgumentException("Option queue is required")))
+      val producer = session.createProducer(queue)
+      rowIter.foreach(
+        record => {
+          val msg = session.createTextMessage(record.toString())
+          producer.send(msg)
+        })
+      producer.close
+      connection.close
+      session.close
+    }
+    )
+    new DataFrameRelation(sqlContext, data)
+  }
+
+  override def sourceSchema(sqlContext: SQLContext, schema: Option[StructType], providerName: String, parameters: Map[String, String]): (String, StructType) = {
+    require(schema.isEmpty, "JMS source has a fixed schema and cannot be set with a custom one")
+    (shortName,ScalaReflection.schemaFor[JmsMessage].dataType.asInstanceOf[StructType])
+  }
+
+  override def createSource(sqlContext: SQLContext, metadataPath: String, schema: Option[StructType], providerName: String, parameters: Map[String, String]): Source = {
+    new JmsStreamingSource(sqlContext,parameters, metadataPath, true)
+  }
+
+  override def createSink(sqlContext: SQLContext, parameters: Map[String, String], partitionColumns: Seq[String], outputMode: OutputMode): Sink = {
+    new JmsStreamingSink(sqlContext,parameters)
+  }
+}
+
+
+object DefaultSource {
+
+  def connectionFactory(parameters: Map[String, String]) = parameters("connection") match {
+    case "amq" => new AMQConnectionFactoryProvider().createConnection(parameters)
+    case "ibmmq" => new IBMMQConnectionFactoryProvider().createConnection(parameters)
+    case "rmq" => new RMQConnectionFactoryProvider().createConnection(parameters)
+    case "kafka" => new KafkaConnectionFactoryProvider().createConnection(parameters)
+    case connection: String => Class.forName(connection).newInstance.asInstanceOf[ConnectionFactoryProvider].createConnection(parameters)
+  }
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/DefaultSource.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/DefaultSource.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ * Copyright 2021 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsDataSourceRelation.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsDataSourceRelation.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import java.util.Collections

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsDataSourceRelation.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsDataSourceRelation.scala
@@ -1,0 +1,68 @@
+package com.splicemachine.spark.jms
+
+import java.util.Collections
+import javax.jms._
+
+import org.apache.activemq.ActiveMQConnectionFactory
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+import scala.beans.BeanProperty
+import scala.collection.mutable.ListBuffer
+
+/**
+  * Created by exa00015 on 17/12/18.
+  */
+class JmsDatasourceRelation(override val sqlContext: SQLContext, parameters: Map[String, String]) extends BaseRelation with TableScan with Serializable {
+
+  lazy val RECIEVER_TIMEOUT = parameters.getOrElse("reciever.timeout","3000").toLong
+
+
+  override def schema: StructType = {
+    ScalaReflection.schemaFor[JmsMessage].dataType.asInstanceOf[StructType]
+  }
+
+  override def buildScan(): RDD[Row] = {
+    val connection = DefaultSource.connectionFactory(parameters).createConnection
+    val session: Session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)
+    connection.start
+    var messageRdd:RDD[Row] = null
+    try {
+      val queue = session.createQueue(parameters("queue"))
+      val consumer = session.createConsumer(queue)
+      var break = true
+      val messageList :ListBuffer[JmsMessage] = ListBuffer()
+      while (break) {
+        val textMsg = consumer.receive(RECIEVER_TIMEOUT).asInstanceOf[TextMessage]
+        /*textMsg  match {
+          case msg:TextMessage =>
+          case msg:BytesMessage => {
+            var byteData:Array[Byte] = null
+            byteData = new Array[Byte](msg.getBodyLength.asInstanceOf[Int])
+            msg.readBytes(byteData)
+          }
+          case msg:ObjectMessage=> msg.getObject
+          case msg:StreamMessage =>
+          case msg:MapMessage =>
+        }*/
+        if(parameters.getOrElse("acknowledge","false").toBoolean && textMsg !=null){
+          textMsg.acknowledge
+        }
+        textMsg match {
+          case null => break = false
+          case _ =>  messageList += JmsMessage(textMsg)
+        }
+      }
+      import scala.collection.JavaConverters._
+      val messageDf = sqlContext.createDataFrame(messageList.toList.asJava,classOf[JmsMessage])
+      messageRdd = messageDf.rdd
+    } finally {
+      connection.close
+    }
+    messageRdd
+  }
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsMessage.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsMessage.scala
@@ -1,0 +1,35 @@
+package com.splicemachine.spark.jms
+
+import com.ibm.msg.client.jms.JmsConstants
+import javax.jms.{BytesMessage, MapMessage, ObjectMessage, StreamMessage, TextMessage}
+
+import scala.beans.BeanProperty
+
+/**
+  * Created by exa00015 on 26/12/18.
+  */
+case class JmsMessage( @BeanProperty content:String, @BeanProperty correlationId:String, @BeanProperty jmsType:String,@BeanProperty messageId:String , @BeanProperty queue:String)
+
+
+object JmsMessage {
+
+  def apply(message:TextMessage): JmsMessage =
+    new JmsMessage(message.getText, message.getJMSCorrelationID, message.getJMSType, message.getJMSMessageID,message.getJMSDestination.toString)
+
+  def apply(message:BytesMessage): JmsMessage = {
+    val TEXT_LENGTH = message.getBodyLength.intValue
+    val textBytes = new Array[Byte](TEXT_LENGTH)
+    message.readBytes(textBytes, TEXT_LENGTH)
+    val codePage = message.getStringProperty(JmsConstants.JMS_IBM_CHARACTER_SET)
+    new JmsMessage(new String(textBytes, codePage), message.getJMSCorrelationID, message.getJMSType, message.getJMSMessageID, message.getJMSDestination.toString)
+  }
+  
+  def apply(message:MapMessage): JmsMessage = null
+
+  def apply(message:ObjectMessage): JmsMessage = null
+
+  def apply(message:StreamMessage): JmsMessage = null
+
+  def apply(): JmsMessage = null
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsMessage.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsMessage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ * Copyright 2021 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import com.ibm.msg.client.jms.JmsConstants

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceOffset.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceOffset.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import org.apache.spark.sql.execution.streaming.Offset

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceOffset.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceOffset.scala
@@ -1,0 +1,12 @@
+package com.splicemachine.spark.jms
+
+import org.apache.spark.sql.execution.streaming.Offset
+
+/**
+  * Created by exa00015 on 26/12/18.
+  */
+case class JmsSourceOffset(val id:Long) extends Offset {
+
+  override def json(): String = id.toString
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceRdd.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceRdd.scala
@@ -1,0 +1,17 @@
+package com.splicemachine.spark.jms
+
+import javax.jms.Message
+
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+
+/**
+  * Created by exa00015 on 26/12/18.
+  */
+class JmsSourceRdd(sc:SparkContext) extends RDD[Message](sc, Nil){
+
+  override def compute(split: Partition, context: TaskContext): Iterator[Message] = ???
+
+  override protected def getPartitions: Array[Partition] = ???
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceRdd.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsSourceRdd.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import javax.jms.Message

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsStreamingSink.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsStreamingSink.scala
@@ -1,0 +1,40 @@
+package com.splicemachine.spark.jms
+
+import javax.jms.Session
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.execution.streaming.Sink
+
+/**
+  * Created by exa00015 on 26/12/18.
+  */
+class JmsStreamingSink(sqlContext: SQLContext,
+                       parameters: Map[String, String]
+                      ) extends Sink {
+
+  @volatile private var latestBatchId = -1L
+
+
+  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+    if (batchId <= latestBatchId) {
+
+    } else {
+      data.foreachPartition((rowIter: Iterator[Row]) => {
+        val connection = DefaultSource.connectionFactory(parameters).createConnection
+        val session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+        val queue = session.createQueue(parameters.getOrElse("queue",throw new IllegalArgumentException("Option queue is required")))
+        val producer = session.createProducer(queue)
+        rowIter.foreach(
+          record => {
+            val msg = session.createTextMessage(record.toString())
+            producer.send(msg)
+          })
+        producer.close
+        connection.close
+        session.close
+      }
+      )
+      latestBatchId = batchId
+    }
+  }
+
+}

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsStreamingSink.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/JmsStreamingSink.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ * Copyright 2021 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import javax.jms.Session

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/SparkApp.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/SparkApp.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ * Copyright 2021 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splicemachine.spark.jms
 
 import java.io.StringReader

--- a/spark3.0/src/main/scala/com/splicemachine/spark/jms/SparkApp.scala
+++ b/spark3.0/src/main/scala/com/splicemachine/spark/jms/SparkApp.scala
@@ -1,0 +1,162 @@
+package com.splicemachine.spark.jms
+
+import java.io.StringReader
+
+import javax.xml.namespace.QName
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamConstants
+import javax.xml.stream.events.XMLEvent
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{Row, SQLContext, SaveMode}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+//import org.apache.spark.sql.types._
+
+/**
+  * Created by exa00015 on 21/12/18.
+  */
+object SparkApp {
+
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf().setMaster("local").setAppName("Sql starter")
+    val sparkContext = new SparkContext(conf)
+    val sqlContext = new SQLContext(sparkContext)
+    val sparkSession = sqlContext.sparkSession
+    import sparkSession.implicits._
+
+    val stream = sparkSession.readStream
+      .format("jk.bigdata.tech.jms")
+      .option("connection","ibmmq")
+      .option("host","stl-colo-srv006")
+      .option("port","1414")
+      .option("channel","DEV.APP.SVRCONN")
+      .option("queue_manager","QM1")
+      .option("queue","DEV.QUEUE.1")
+      .option("message_type","bytes")
+      .option("userid","app")
+      .option("password","passw0rd")
+      .option("application","SparkApp0")
+      .load
+//      .select(col("content") as "klog_xml")
+      .map( row => {
+        val xml = row.getAs[String]("content")
+        println("**********")
+        println(xml)
+        val eventReader = XMLInputFactory.newInstance.createXMLEventReader(new StringReader(xml))
+        var inKlog = false
+        var inTransaction = false
+        var inBusinessUnit = false
+        val data = collection.mutable.Map[String,String]()
+        data += "klog_xml" -> xml
+        while( data.size < 8 && eventReader.hasNext ) {
+          val event = eventReader.nextEvent
+          event.getEventType match {
+            case XMLStreamConstants.START_ELEMENT => {
+              val startElement = event.asStartElement
+              startElement.getName.getLocalPart.toUpperCase match {
+                case "KLOG" => inKlog = true
+                case "TRANSACTION" => if( inKlog ) {
+                  inTransaction = true
+                  data += ("transaction_type" -> startElement.getAttributeByName(new QName("TypeCode")).getValue)
+                }
+                case "BUSINESSUNIT" => if( inTransaction ) { inBusinessUnit = true }
+                case "UNITID" => if( inBusinessUnit ) {
+                  data += ("store_id" -> eventReader.getElementText)
+                }
+                case "RECEIPTDATETIME" => if( inTransaction ) {
+                  data += ("transaction_date" -> eventReader.getElementText)
+                }
+                case "WORKSTATIONID" => if( inTransaction ) {
+                  data += ("workstation_id" -> eventReader.getElementText)
+                }
+                case "SEQUENCENUMBER" => if( inTransaction ) {
+                  data += ("transaction_number" -> eventReader.getElementText)
+                }
+                case "POSLOGDATETIME" => if( inTransaction ) {
+                  data += ("created_ts" -> eventReader.getElementText)
+                }
+                case "OPERATORID" => if( inTransaction ) {
+                  data += ("created_by" -> eventReader.getElementText)
+                }
+                case _ => {}
+              }
+            }
+            case XMLStreamConstants.END_ELEMENT => {
+              val endElement = event.asEndElement
+              endElement.getName.getLocalPart.toUpperCase match {
+                case "KLOG" => inKlog = false
+                case "TRANSACTION" => if (inKlog) { inTransaction = false }
+                case "BUSINESSUNIT" => if (inTransaction) { inBusinessUnit = false }
+                case _ => {}
+              }
+            }
+            case _ => {}
+          }
+        }
+        Row(
+          data.getOrElse("store_id", ""),
+          data.getOrElse("transaction_date", ""),
+          data.getOrElse("workstation_id", ""),
+          data.getOrElse("transaction_number", ""),
+          data.getOrElse("transaction_type", ""),
+          data.getOrElse("klog_xml", ""),
+          data.getOrElse("created_ts", ""),
+          data.getOrElse("created_by", "")
+        )
+      }) (RowEncoder(
+          StructType(Seq(
+            StructField("store_id", StringType),
+            StructField("transaction_date", StringType),
+            StructField("workstation_id", StringType),
+            StructField("transaction_number", StringType),
+            StructField("transaction_type", StringType),
+            StructField("klog_xml", StringType),
+            StructField("created_ts", StringType),
+            StructField("created_by", StringType)
+          ))
+      ))
+
+//    BusinessUnit.UnitID — store_id string
+//    ReceiptDateTime — transaction_date timestamp
+//    WorkstationID — workstation_id numeric(8,0)
+//    SequenceNumber — transaction_number numeric(8,0)
+//    Transaction.TypeCode — transaction_type string
+//    Entire xml — klog_xml clob
+//    POSLogDateTime — created_ts timestamp
+//    OperatorID — created_by string
+
+    val query = stream.writeStream
+      .outputMode("append")
+      .format("console")
+      .start()
+
+    query.awaitTermination
+    query.stop
+    sparkSession.stop
+
+    /*
+    import sparkSession.implicits._
+    val df = sparkSession
+      .readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+      .option("subscribe", "connect-configs")
+      .load()
+    df.selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+      .as[(String, String)]
+
+    val query = df.writeStream
+      .outputMode("append")
+      .format("console")
+      .start()
+    //result.show(20,false)
+    /*result.write.mode(SaveMode.Append)
+      .format("jk.bigdata.tech.jms")
+      .option("connection","jk.bigdata.tech.jms.AMQConnectionFactoryProvider")
+      .option("queue","customerQueue")
+      .save*/
+      */
+  }
+
+}

--- a/spark3.0/src/main/scala/org/apache/spark/sql/jms/JmsStreamingSource.scala
+++ b/spark3.0/src/main/scala/org/apache/spark/sql/jms/JmsStreamingSource.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 https://github.com/jksinghpro/spark-jms
+ * Copyright 2021 Splice Machine, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.jms
 
 import javax.jms._

--- a/spark3.0/src/main/scala/org/apache/spark/sql/jms/JmsStreamingSource.scala
+++ b/spark3.0/src/main/scala/org/apache/spark/sql/jms/JmsStreamingSource.scala
@@ -1,0 +1,82 @@
+package org.apache.spark.sql.jms
+
+import javax.jms._
+import org.apache.spark.sql.catalyst.{InternalRow, ScalaReflection}
+import org.apache.spark.sql.execution.streaming.{Offset, Source}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import com.splicemachine.spark.jms.{DefaultSource, JmsMessage, JmsSourceOffset}
+
+import scala.collection.mutable.ListBuffer
+
+/**
+  * Created by exa00015 on 25/12/18.
+  */
+
+class JmsStreamingSource(sqlContext: SQLContext,
+                         parameters: Map[String, String],
+                         metadataPath: String,
+                         failOnDataLoss: Boolean
+                        ) extends Source {
+
+  var counter = sqlContext.sparkContext.longAccumulator("counter")
+
+  lazy val RECEIVER_TIMEOUT = parameters.getOrElse("receiver.timeout", "3000").toLong
+
+
+  val connection = DefaultSource.connectionFactory(parameters).createConnection
+  val session: Session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)
+  connection.start
+
+  override def schema: StructType = {
+    ScalaReflection.schemaFor[JmsMessage].dataType.asInstanceOf[StructType]
+  }
+
+  override def getOffset: Option[Offset] = {
+    counter.add(1)
+    Some(JmsSourceOffset(counter.value))
+  }
+  
+  override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
+    val queue = session.createQueue(parameters("queue"))
+    val consumer = session.createConsumer(queue)
+    var retrieving = true
+    val messageList: ListBuffer[JmsMessage] = ListBuffer()
+    val ack = parameters.getOrElse("acknowledge", "false").toBoolean
+    def getMessage: Option[JmsMessage] = consumer.receive(RECEIVER_TIMEOUT) match {
+      case null => None
+      case msg: Message => {
+        if(ack) { msg.acknowledge }
+        Some(
+          parameters("message_type") match {
+            case "bytes" => JmsMessage( msg.asInstanceOf[BytesMessage] )
+            case _ => JmsMessage( msg.asInstanceOf[TextMessage] )
+          }
+        )
+      }
+    }
+    while (retrieving) {
+      getMessage match {
+        case Some(msg) => messageList += msg
+        case None => retrieving = false
+      }
+    }
+    import org.apache.spark.unsafe.types.UTF8String._
+    val internalRDD = messageList.map(message => InternalRow(
+      fromString(message.content),
+      fromString(message.correlationId),
+      fromString(message.jmsType),
+      fromString(message.messageId),
+      fromString(message.queue)
+    ))
+    val rdd = sqlContext.sparkContext.parallelize(internalRDD)
+    sqlContext.internalCreateDataFrame(rdd, schema, true)
+  }
+
+  override def stop(): Unit = {
+    session.close
+    connection.close
+  }
+
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Support JMS input for spark structured streaming.

## Long Description
This code was added to be able to read data from IBM MQ via JMS.

## How to test
Bob had a server set up and generating data that the streaming code could read.